### PR TITLE
Objects and Documents can be json encoded.

### DIFF
--- a/src/Core/Object.php
+++ b/src/Core/Object.php
@@ -1,8 +1,10 @@
 <?php
 
 namespace Demand\Core;
+use JsonSerializable;
+use ArrayAccess;
 
-class Object implements \ArrayAccess
+class Object implements ArrayAccess, JsonSerializable
 {
     /** @var array */
     protected $_values;
@@ -92,6 +94,10 @@ class Object implements \ArrayAccess
             return json_encode($this->toArray(true));
     }
 
+    public function jsonSerialize()
+    {
+        return $this->toArray(true);
+    }
     public function toString()
     {
         return $this->toJson();

--- a/tests/Core/ObjectTest.php
+++ b/tests/Core/ObjectTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Core;
+
+use Demand\Core\Object;
+use PHPUnit_Framework_TestCase;
+
+class ObjectTest extends PHPUnit_Framework_TestCase
+{
+    public function testObjectIsJsonEncodable()
+    {
+        $sampleArray = [
+            'first_name'    => 'John',
+            'age'           => 32,
+            'is_married'    => true,
+            'empty_field'   => '',
+            'children'      => ['Marry', 'Sam']
+        ];
+
+        $object = new Object($sampleArray);
+
+        $actual = json_encode($object);
+        $expected = json_encode($sampleArray);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testEmptyObjectIsJsonEncodable()
+    {
+        $actual = json_encode(new Object());
+        $expected = json_encode([]);
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
As of now if run `json_encode` on non-empty object, it produces `{}`. Proposed feature would `json_encode` an array instead which produces valid json.