### PR TITLE
Allow disabling potato doc hydration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="vendor/autoload.php">
+<testsuites>
+  <testsuite name="tests">
+    <directory>tests</directory>
+  </testsuite>
+</testsuites>
+</phpunit>

--- a/src/Demand/Potato/Client.php
+++ b/src/Demand/Potato/Client.php
@@ -34,13 +34,9 @@ class Client
      * changed.
      *
      * @param array $options (default: array()) config options
-     * @param \CouchbaseCluster|null $couchbaseCluster (default: null) Optional
-     * couchbase cluster to use, else one will be initialized for you
      */
-    public function __construct(
-        $options = array(),
-        \CouchbaseCluster $cluster = null
-    ) {
+    public function __construct($options = array())
+    {
         $defaults = array(
             'name' => null,
             'uri' => 'http://127.0.0.1:8091',
@@ -52,12 +48,15 @@ class Client
             'connect' => true,
             'transcoder' => 'json',
             'environment' => 'development',
+            'cluster' => null,
             'hydrate' => true
         );
         $this->config = $options + $defaults;
         $this->config['name'] = $this->config['name'] ?: $this->config['bucket'];
-        if ($cluster) {
-            $this->cluster = $cluster;
+
+        // allow injecting a cluster, otherwise one will be created for you in init.
+        if ($this->config['cluster']) {
+            $this->cluster = $this->config['cluster'];
         }
         $this->init();
     }

--- a/tests/Demand/Potato/ClientTest.php
+++ b/tests/Demand/Potato/ClientTest.php
@@ -39,7 +39,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         // mock dependencies
         $this->cluster = $this->prophesize(CouchbaseCluster::class);
         // instantiate class under test
-        $this->client = new Client([], $this->cluster->reveal());
+        $this->client = new Client(['cluster' => $this->cluster->reveal()]);
     }
 
     public function testFetchDocumentWithHydrationDisabled()

--- a/tests/Potato/ClientTest.php
+++ b/tests/Potato/ClientTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * ClientTest
+ *
+ * @copyright 2016 Demand Media, Inc. All Rights Reserved.
+ */
+namespace Demand\Potato;
+
+use CouchbaseCluster;
+use CouchbaseBucket;
+use CouchbaseMetaDoc;
+use Demand\Potato\Document as PotatoDocument;
+
+/**
+ * Unit Tests.
+ *
+ * @see Demand\Potato\Client
+ *
+ * @author Michael Funk <mike.funk@demandmedia.com>
+ */
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var Demand\Potato\Client class under test
+     */
+    protected $client;
+
+    /**
+     * @var CouchbaseCluster
+     */
+    protected $cluster;
+
+    /**
+     * Phpunit before each test.
+     */
+    public function setUp()
+    {
+        // mock dependencies
+        $this->cluster = $this->prophesize(CouchbaseCluster::class);
+        // instantiate class under test
+        $this->client = new Client([], $this->cluster->reveal());
+    }
+
+    public function testFetchDocumentWithHydrationDisabled()
+    {
+        // dummy data
+        $id = 8686920;
+        // it should open a bucket
+        $bucket = $this->prophesize(CouchbaseBucket::class);
+        $this->cluster->openBucket('default')->willReturn($bucket->reveal());
+        // it should get a response
+        $response = $this->prophesize(CouchbaseMetaDoc::class);
+        $expected = $response->reveal();
+        $bucket->get($id)->willReturn($expected);
+        // one assoc array should be returned
+        // call and verify
+        $actual = $this->client->fetchDocument($id, ['hydrate' => false]);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testFetchMultipleDocumentsWithHydrationDisabled()
+    {
+        // dummy data
+        $ids = [8686920];
+        // it should open a bucket
+        $bucket = $this->prophesize(CouchbaseBucket::class);
+        $this->cluster->openBucket('default')->willReturn($bucket->reveal());
+        // it should get a response
+        $response = $this->prophesize(CouchbaseMetaDoc::class);
+        $expected = [$response->reveal()];
+        $bucket->get($ids)->willReturn($expected);
+        // multiple assoc arrays should be returned
+        // call and verify
+        $actual = $this->client->fetchDocument($ids, ['hydrate' => false]);
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
This adds an option to hydrate potato documents, which are respected on
returning results. Tests added for those cases. I also added an *option*
to pass a couchbase cluster in the constructor to allow for mocking the
cluster in testing, which was used in the unit test. Backward
compatible.

Also this is PR'd into master. If you'd like me to switch it to develop, let 
me know, no prob.