### PR TITLE
Fetch doc ids as array keys in multi fetch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "demand/potato",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "description": "A simple ODM for couchbase",
     "homepage": "http://github.com/saatchiart/potato",
     "type": "library",

--- a/src/Demand/Potato/Client.php
+++ b/src/Demand/Potato/Client.php
@@ -103,18 +103,18 @@ class Client
     {
         $options = $options + $this->config;
         $response = $this->getBucket()->get($ids);
+        if (!$options['hydrate']) {
+            return $response;
+        }
         if (is_array($response)) {
             $docs = array();
             foreach ($response as $id => $result) {
-                $docs[] = $options['hydrate'] ?
-                    $this->hydrate($id,$result,$options) :
-                    $result;
+                $docs[] = $this->hydrate($id, $result, $options);
             }
+
             return $docs;
         } else {
-            return $options['hydrate'] ?
-                $this->hydrate($ids,$response,$options) :
-                $response;
+            return $this->hydrate($ids,$response,$options);
         }
     }
 

--- a/tests/Demand/Potato/ClientTest.php
+++ b/tests/Demand/Potato/ClientTest.php
@@ -68,7 +68,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->cluster->openBucket('default')->willReturn($bucket->reveal());
         // it should get a response
         $response = $this->prophesize(CouchbaseMetaDoc::class);
-        $expected = [$response->reveal()];
+        $expected = [$ids[0] => $response->reveal()];
         $bucket->get($ids)->willReturn($expected);
         // multiple assoc arrays should be returned
         // call and verify


### PR DESCRIPTION
When fetching multiple ids with hydration disabled, return the ids as array 
keys for each `CouchbaseMetaDoc`. Otherwise I have no way of retrieving 
the key for each doc when fetching multiple docs at once. Updated tests 
to match.